### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   build:
     name: Build website
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/abianche/skroll-website/security/code-scanning/1](https://github.com/abianche/skroll-website/security/code-scanning/1)

To fix the problem, add a `permissions` block with minimal necessary permissions to the `build` job. Since the job only needs to check out the repository (which requires `contents: read`), this is sufficient. The fix involves editing `.github/workflows/deploy.yml`, locating the start of the `build` job, and inserting a `permissions:` block below `name: Build website` (or anywhere before `steps:`). This change restricts the GITHUB_TOKEN's permissions, following recommended security practices.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
